### PR TITLE
simple CRUD interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM julia:1.8.1
+
+ADD src /model-transform
+
+# Pre-install Catlab related dependencies
+RUN julia -e 'import Pkg; Pkg.update()' && \
+    julia -e 'import Pkg; Pkg.add("UUIDs"); using UUIDs' && \
+    julia -e 'import Pkg; Pkg.add("Catlab"); using Catlab' && \
+    julia -e 'import Pkg; Pkg.add("Genie"); using Genie' && \
+    julia -e 'import Pkg; Pkg.add("AlgebraicPetri"); using AlgebraicPetri' && \
+    julia -e 'import Pkg; Pkg.add("DifferentialEquations"); using DifferentialEquations' && \
+    julia -e 'import Pkg; Pkg.add("JSON"); using JSON'
+
+CMD julia model-transform/service.jl

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Model Transform
+This is a webservice that provies a REST-API wrappers around [Catlab.jl](https://github.com/AlgebraicJulia/Catlab.jl). 
+
+
+## Docker image
+The Dockerfile provides a runnable web-service
+
+```
+docker build . -t askem-model-transform
+```

--- a/src/service.jl
+++ b/src/service.jl
@@ -1,0 +1,133 @@
+module demo
+
+# See Genine framework example here
+# https://genieframework.github.io/Genie.jl/dev/tutorials/5--Handling_Query_Params.html
+#
+# See also this notebook
+# https://github.com/AlgebraicJulia/Structured-Epidemic-Modeling/
+
+using UUIDs
+using Genie
+using Genie.Requests
+using Genie.Renderer.Json
+
+using Catlab
+using Catlab.CategoricalAlgebra 
+using Catlab.Programs
+using Catlab.WiringDiagrams
+using Catlab.Graphics.Graphviz
+using AlgebraicPetri
+
+const modelDict = Dict{String, LabelledPetriNet}()
+
+
+# Retrieve a model
+route("/api/models/:model_id") do
+    key = payload(:model_id)
+    println(" Checking key $(key) => $(haskey(modelDict, key))")
+
+    if !haskey(modelDict, key) 
+        return json("not found")
+    end
+    model = modelDict[key]
+    return json(model)
+end
+
+
+# Create a new empty model
+route("/api/models", method = PUT) do
+    # @info "Creating new model"
+    modelId = string(UUIDs.uuid4())
+
+    # Debugging
+    # modelId = "xyz"
+
+    model = LabelledPetriNet()
+    modelDict[modelId] = model
+
+    println(modelDict)
+
+    return json(
+         Dict([ 
+               (:id, modelId)
+         ])
+    )
+end
+
+
+# Add nodes and edges, a more natural way of adding components instead of solely relying 
+# on indices
+route("/api/models/:model_id", method = POST) do
+    key = payload(:model_id)
+    println(" Checking key $(key) => $(haskey(modelDict, key))")
+
+    if !haskey(modelDict, key) 
+        return json("not found")
+    end
+
+    model = modelDict[key]
+    data = jsonpayload()
+
+    # nodes, need to be processed first, otherwise index assignment will fail for edges
+    if haskey(data, "nodes")
+        for n in data["nodes"]
+            if n["type"] == "S"
+                add_parts!(model, :S, 1, sname=Symbol(n["name"]))
+            elseif n["type"] == "T"
+                add_parts!(model, :T, 1, tname=Symbol(n["name"]))
+            end
+        end
+    end
+
+    # edges
+    if haskey(data, "edges")
+        subparts = model.subparts
+
+        for e in data["edges"]
+
+            source = Symbol(e["source"])
+            target = Symbol(e["target"])
+
+            if isnothing(findfirst(x -> x == source, subparts.sname)) == false 
+                sourceIdx = findfirst(x -> x == source, subparts.sname)
+                targetIdx = findfirst(x -> x == target, subparts.tname)
+
+                add_parts!(model, :I, 1, is=sourceIdx, it=targetIdx)
+            end
+
+            if isnothing(findfirst(x -> x == source, subparts.tname)) == false
+                sourceIdx = findfirst(x -> x == source, subparts.tname)
+                targetIdx = findfirst(x -> x == target, subparts.sname)
+
+                add_parts!(model, :O, 1, os=sourceIdx, ot=targetIdx) 
+            end
+        end
+    end
+    
+    # Serialize back
+    # println("Serializing back")
+    modelDict[key] = model
+
+    return json("done")
+end
+
+
+# Get JSON representation of the model
+route("/api/models/:model_id/json") do
+    key = payload(:model_id)
+
+    if !haskey(modelDict, key) 
+        return json("not found")
+    end
+
+    model = modelDict[key]
+    dataOut = generate_json_acset(model)
+
+    return json(dataOut)
+end
+
+
+# Start the API
+up(8888, "0.0.0.0", async = false)
+
+end # module


### PR DESCRIPTION
### Summary
Simple CRUD API to kick things off, this will allow the creation of a PetriNet in Catlab's internal format piece by piece.

You can either
- Run `julia src/service.jl`, or
- Build a docker image `docker build . -t aksem-model-transform` and `docker run -p 8888:8888 askem-model-transform`, note this will take some time to build.

### Testing
Replace xyz with the model id
```
curl -XPUT -H "Content-type: application/json" localhost:8888/api/models


curl -XPOST -H "Content-type: application/json" localhost:8888/api/models/xyz -d'
{
  "nodes": [
    { "name": "Hello", "type": "S" },
    { "name": "World", "type": "T" }
  ]
}'


curl -XPOST -H "Content-type: application/json" localhost:8888/api/models/xyz -d'
{
  "edges": [
    { "source": "Hello", "target": "World" },
    { "source": "World", "target": "Hello" }
  ]
}'


curl -XGET -H "Content-type: application/json" localhost:8888/api/models/xyz/json 
```
